### PR TITLE
Add draft Cloudwatch dashboard 

### DIFF
--- a/infrastructure/bin/zoorl-infrastructure.ts
+++ b/infrastructure/bin/zoorl-infrastructure.ts
@@ -5,6 +5,7 @@ import { ZoorlInfrastructureStack } from '../lib/zoorl-infrastructure-stack';
 
 const app = new cdk.App();
 new ZoorlInfrastructureStack(app, 'ZoorlInfrastructureStack', {
+  stage: "dev"
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/infrastructure/lib/auth-stack.ts
+++ b/infrastructure/lib/auth-stack.ts
@@ -1,0 +1,80 @@
+// Copyright Mario Scalas 2022. All Rights Reserved.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as cdk from 'aws-cdk-lib';
+import * as constructs from "constructs";
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+
+/**
+ * Configuration properties for the AuthStack.
+ */
+ export interface AuthStackProps extends cdk.NestedStackProps {
+    /**
+     * The base name that will be use for naming User and Identity pools.
+     */
+    readonly basePoolName?: string;
+}
+
+/**
+ * Authentication resources - essentially our Cognito User and Identity pools.
+ */
+export class AuthStack extends cdk.NestedStack {
+    public readonly userPool: cognito.UserPool;
+    public readonly userPoolClient: cognito.UserPoolClient;
+    public readonly identityPool: cognito.CfnIdentityPool;
+
+    public readonly userPoolIdOutput: cdk.CfnOutput;
+    public readonly userPoolClientIdOutput: cdk.CfnOutput;
+    public readonly identityPoolIdOutput: cdk.CfnOutput;
+
+    public readonly regionOutput: cdk.CfnOutput;
+
+    constructor(scope: constructs.Construct, id: string, props?: AuthStackProps) {
+        super(scope, id, props);
+
+        const poolName = props?.basePoolName || `zoorl-${this.region}`;
+
+        this.userPool = new cognito.UserPool(this, "user-pool", {
+            userPoolName: `${poolName}-up`,
+            selfSignUpEnabled: true, // Allow users to sign up
+            autoVerify: { email: true }, // Verify email addresses by sending a verification code
+            signInAliases: { email: true } // Set email as alias
+        });
+
+        this.userPoolClient = new cognito.UserPoolClient(this, "user-pool-client", {
+            userPool: this.userPool,
+            authFlows: {
+                adminUserPassword: true,
+                userSrp: true
+            },
+            generateSecret: false // No need to generate a secret for webapps running in browser
+        });
+
+        this.identityPool = new cognito.CfnIdentityPool(this, "identity-pool", {
+            identityPoolName: `${poolName}-idp`,
+            allowUnauthenticatedIdentities: true,
+            cognitoIdentityProviders: [{
+                clientId: this.userPoolClient.userPoolClientId,
+                providerName: this.userPool.userPoolProviderName
+            }]
+        });
+
+
+        this.identityPoolIdOutput = new cdk.CfnOutput(this, "IdentityPoolId", {
+            exportName: "IdentityPoolId",
+            value: this.identityPool.ref || ""
+        });
+        this.userPoolClientIdOutput = new cdk.CfnOutput(this, "UserPoolClientId", {
+            exportName: "UserPoolClientId",
+            value: this.userPoolClient.userPoolClientId || ""
+        });
+        this.userPoolIdOutput = new cdk.CfnOutput(this, "UserPoolId", {
+            exportName: "UserPoolId",
+            value: this.userPool.userPoolId || ""
+        });
+        this.regionOutput = new cdk.CfnOutput(this, "Region", {
+            value: this.region || ""
+        });
+    }
+}

--- a/infrastructure/lib/observability-stack.ts
+++ b/infrastructure/lib/observability-stack.ts
@@ -1,125 +1,62 @@
-import { Stack, StackProps, Duration } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { Dashboard, GraphWidget, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+// Copyright Mario Scalas 2022. All Rights Reserved.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
 
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Dashboard, TextWidget } from 'aws-cdk-lib/aws-cloudwatch';
+import { IObservabilityContributor } from './shared/common-observability';
+
+/**
+ * Configuration properties for the observability stack.
+ */
 interface ObservabilityStackProps extends StackProps {
 	readonly stage: string;
-	readonly functionName: string;
 }
 
+/**
+ * Dashboard and metrics stack.
+ */
 export class ObservabilityStack extends Stack {
+
+    private readonly dashboard: Dashboard;
+
 	constructor(scope: Construct, id: string, props: ObservabilityStackProps) {
 		super(scope, id, props);
 
-		const dashboard = new Dashboard(
+		this.dashboard = new Dashboard(
 			this,
 			`Zoorl-Dashboard-${props.stage}`, {
 				dashboardName: `Zoorl-Dashboard_${props.stage}`,
 			}
 		);
 
-		//Widgets related to the Lambda function
-		dashboard.addWidgets(
-			new GraphWidget({
-				title: 'AWS Function URL 4xx/5xx errors (sum)',
-				width: 12,
-				left: [
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'Url5xxCount',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'sum',
-						label: 'Sum 5xx Errors',
-						period: Duration.minutes(1),
-					}),
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'Url4xxCount',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'sum',
-						label: 'Sum 4xx Errors',
-						period: Duration.minutes(1),
-					}),
-				],
-			}),
-			new GraphWidget({
-				title: 'AWS Function Errors (sum)',
-				width: 12,
-				left: [
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'Errors',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'sum',
-						label: 'Sum',
-						period: Duration.minutes(1),
-					}),
-				],
-			}),
-			new GraphWidget({
-				title: 'AWS Function URL Request Duration and Latency (p99)',
-				width: 12,
-				left: [
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'UrlRequestLatency',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'p99',
-						label: 'p99 Latency',
-						period: Duration.minutes(1),
-					}),
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'Duration',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'p99',
-						label: 'p99 Duration',
-						period: Duration.minutes(1),
-					}),
-				],
-			}),
-			new GraphWidget({
-				title: 'AWS Function Invocations (sum)',
-				width: 12,
-				left: [
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'Invocations',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'sum',
-						label: 'Sum',
-						period: Duration.minutes(1),
-					}),
-				],
-			}),
-			new GraphWidget({
-				title: 'AWS Function Concurrent executions (Max)',
-				width: 12,
-				left: [
-					new Metric({
-						namespace: 'AWS/Lambda',
-						metricName: 'ConcurrentExecutions',
-						dimensionsMap: {
-							FunctionName: props.functionName,
-						},
-						statistic: 'max',
-						label: 'Max',
-						period: Duration.minutes(1),
-					}),
-				],
-			})
-		);
+        this.dashboard.addWidgets(
+            new TextWidget({
+                markdown: `# Zoorl - Function Metrics 
+Here you can see all the metrics for the *Zoorl* stack. These includes
+
+## Available metrics
+* Lambda functions
+
+## TODO metrics
+* API Gateway
+* DynamoDB tables
+                `,
+                width: 24,
+                height: 6,
+            })
+        );
+
+		// Note: sections are contributed by microservices implementing IObservabilityContributor
 	}
+
+    hookDashboardContributions(contributors: IObservabilityContributor[]): void {
+        if (!contributors)
+            return;
+        
+        contributors.forEach( 
+            (contributor) => contributor.contributeWidgets(this.dashboard) 
+        );
+    }
 }

--- a/infrastructure/lib/observability-stack.ts
+++ b/infrastructure/lib/observability-stack.ts
@@ -1,0 +1,125 @@
+import { Stack, StackProps, Duration } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Dashboard, GraphWidget, Metric } from 'aws-cdk-lib/aws-cloudwatch';
+
+interface ObservabilityStackProps extends StackProps {
+	readonly stage: string;
+	readonly functionName: string;
+}
+
+export class ObservabilityStack extends Stack {
+	constructor(scope: Construct, id: string, props: ObservabilityStackProps) {
+		super(scope, id, props);
+
+		const dashboard = new Dashboard(
+			this,
+			`Zoorl-Dashboard-${props.stage}`, {
+				dashboardName: `Zoorl-Dashboard_${props.stage}`,
+			}
+		);
+
+		//Widgets related to the Lambda function
+		dashboard.addWidgets(
+			new GraphWidget({
+				title: 'AWS Function URL 4xx/5xx errors (sum)',
+				width: 12,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Url5xxCount',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Sum 5xx Errors',
+						period: Duration.minutes(1),
+					}),
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Url4xxCount',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Sum 4xx Errors',
+						period: Duration.minutes(1),
+					}),
+				],
+			}),
+			new GraphWidget({
+				title: 'AWS Function Errors (sum)',
+				width: 12,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Errors',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Sum',
+						period: Duration.minutes(1),
+					}),
+				],
+			}),
+			new GraphWidget({
+				title: 'AWS Function URL Request Duration and Latency (p99)',
+				width: 12,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'UrlRequestLatency',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'p99',
+						label: 'p99 Latency',
+						period: Duration.minutes(1),
+					}),
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Duration',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'p99',
+						label: 'p99 Duration',
+						period: Duration.minutes(1),
+					}),
+				],
+			}),
+			new GraphWidget({
+				title: 'AWS Function Invocations (sum)',
+				width: 12,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Invocations',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Sum',
+						period: Duration.minutes(1),
+					}),
+				],
+			}),
+			new GraphWidget({
+				title: 'AWS Function Concurrent executions (Max)',
+				width: 12,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'ConcurrentExecutions',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'max',
+						label: 'Max',
+						period: Duration.minutes(1),
+					}),
+				],
+			})
+		);
+	}
+}

--- a/infrastructure/lib/shared/common-observability.ts
+++ b/infrastructure/lib/shared/common-observability.ts
@@ -1,0 +1,192 @@
+// Copyright Mario Scalas 2022. All Rights Reserved.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import { 
+    Dashboard,
+    Metric,
+    GraphWidget,
+    TextWidget
+} from "aws-cdk-lib/aws-cloudwatch";
+
+/**
+ * Half horizontal screen space within a Cloudwatch dashboard space.
+ */
+export const SIZE_HALF_WIDTH = 12;
+
+/**
+ * Full horizontal screen space within a Cloudwatch dashboard space.
+ */
+export const SIZE_FULL_WIDTH = 2 * SIZE_HALF_WIDTH;
+
+/**
+ * Standard resolution for non-custom Cloudwatch metrics is 1 (one) minute.
+ */
+export const STANDARD_RESOLUTION = cdk.Duration.minutes(1);
+
+/**
+ * High resolution for non-custom Cloudwatch metrics is 1 (one) second.
+ */
+export const HIGH_RESOLUTION = cdk.Duration.seconds(1);
+
+/**
+ * Hook interface for contributing widgets to the Cloudwatch Dashboard.
+ */
+export interface IObservabilityContributor {
+    /**
+     * Hook method for contributing new widgets to the dashboard.
+     * 
+     * @param dashboard the target dashboard
+     */
+    contributeWidgets(dashboard: Dashboard): void;
+}
+
+/**
+ * Configuration properties for creating a section for monitoring a specific function.
+ */
+export interface LambdaFunctionSectionProps {
+    /**
+     * The function name is the lambda function id (e.g., typically from CFN).
+     */
+    readonly functionName: string;
+
+    /**
+     * A human-readable name for function (e.g. "Create URL Hash")
+     */
+    readonly functionNameDescription: string;
+
+    /**
+     * An optional description - if not provided, a default one will be set.
+     * Note that you can use markdown syntax here: it will be injected inside the description.
+     */
+    readonly description?: string;
+}
+
+/**
+ * Helper for building dashboard sections in a standard way. 
+ */
+export class ObservabilityHelper {
+    constructor(private readonly dashboard: Dashboard) {}
+
+    /**
+     * Creates a new section inside the target dashboard with metrics for a given function.
+     * 
+     * See https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html for reference.
+     * 
+     * @param props configuration options for this section
+     */
+    public createLambdaFunctionSection(props: LambdaFunctionSectionProps): void {
+        const description = props.description || "Performance monitors for this lambda function."
+
+        this.dashboard.addWidgets(
+            new TextWidget({
+                markdown: `# Function: ${props.functionNameDescription} 
+${description}
+## Metadata
+- Function name: ${props.functionName}`,
+                width: SIZE_FULL_WIDTH,
+                height: 3
+            })
+        );
+
+		//Widgets related to the Lambda function
+		this.dashboard.addWidgets(
+			new GraphWidget({
+				title: 'AWS Function URL 4xx/5xx errors (sum)',
+				width: SIZE_HALF_WIDTH,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Url5xxCount',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Sum 5xx Errors',
+						period: STANDARD_RESOLUTION,
+					}),
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Url4xxCount',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Sum 4xx Errors',
+						period: STANDARD_RESOLUTION,
+					}),
+				],
+			}),
+			new GraphWidget({
+				title: 'AWS Function Invocations and Errors (sum)',
+				width: SIZE_HALF_WIDTH,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Invocations',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Invocations (sum)',
+						period: STANDARD_RESOLUTION,
+					}),
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Errors',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'sum',
+						label: 'Errors (sum)',
+						period: STANDARD_RESOLUTION,
+					}),
+				],
+			}),
+			new GraphWidget({
+				title: 'AWS Function URL Request Duration and Latency (p99)',
+				width: SIZE_HALF_WIDTH,
+				left: [
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'UrlRequestLatency',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'p99',
+						label: 'p99 Latency',
+						period: STANDARD_RESOLUTION,
+					}),
+					new Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'Duration',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'p99',
+						label: 'p99 Duration',
+						period: STANDARD_RESOLUTION,
+					}),
+				],
+			}),
+            new cloudwatch.GraphWidget({
+				title: 'AWS Function Concurrent executions (Max)',
+				width: SIZE_HALF_WIDTH,
+				left: [
+					new cloudwatch.Metric({
+						namespace: 'AWS/Lambda',
+						metricName: 'ConcurrentExecutions',
+						dimensionsMap: {
+							FunctionName: props.functionName,
+						},
+						statistic: 'max',
+						label: 'Max',
+						period: STANDARD_RESOLUTION,
+					}),
+				],
+			})
+		);
+    }
+}


### PR DESCRIPTION
This PR introduces a Cloudwatch dashboard within the stack.

For now, we contribute only widgets for the lambda functions, no other resources (e.g., DynamoDB table, API Gateway)

In order to avoid code duplications, the `common-observability.ts` introduces some helper classes for creating stadard widget definitions for lambda functions. For example, we can easily create two similar sections for each different function.

This is a starting point - in the future we will start monitor more resources and introduce Cloudwatch alarms. 