### PR TITLE
Add DynamoDB and API Gateway to Cloudwatch metrics dashboard

### DIFF
--- a/infrastructure/.prettierignore
+++ b/infrastructure/.prettierignore
@@ -1,1 +1,5 @@
 cdk.out/
+bin/**/*.js
+lib/**/*.js
+test/**/*.js
+**/*.d.ts

--- a/infrastructure/lib/core/microservice-stack.ts
+++ b/infrastructure/lib/core/microservice-stack.ts
@@ -116,13 +116,13 @@ export class CoreMicroserviceStack extends cdk.NestedStack implements IObservabi
     const observabilityHelper = new ObservabilityHelper(dashboard);
 
     observabilityHelper.createLambdaFunctionSection({
-      functionName: this.createUrlHashFunction.functionName,
-      functionNameDescription: "Create URL Hash",
+      function: this.createUrlHashFunction,
+      descriptiveName: "Create URL Hash",
     });
 
     observabilityHelper.createLambdaFunctionSection({
-      functionName: this.readUrlHashFunction.functionName,
-      functionNameDescription: "Read URL Hash",
+      function: this.readUrlHashFunction,
+      descriptiveName: "Read URL Hash",
     });
   }
 
@@ -193,7 +193,6 @@ export class CoreMicroserviceStack extends cdk.NestedStack implements IObservabi
       index: "zoorl/adapters/read_url_hash_handler.py",
     });
     this.urlHashesTable.grantReadData(readUrlHashFunction);
-
     const http404NotFoundResponseModel = props.restApi.addModel(
       "Http404ResponseModel",
       jsonSchema({

--- a/infrastructure/lib/core/microservice-stack.ts
+++ b/infrastructure/lib/core/microservice-stack.ts
@@ -124,6 +124,11 @@ export class CoreMicroserviceStack extends cdk.NestedStack implements IObservabi
       function: this.readUrlHashFunction,
       descriptiveName: "Read URL Hash",
     });
+
+    observabilityHelper.createDynamoDBTableSection({
+      table: this.urlHashesTable,
+      descriptiveName: "URL hashes table",
+    });
   }
 
   private bindCreateUrlHashFunction(props: CoreMicroserviceStackProps): lambda.Function {

--- a/infrastructure/lib/observability-stack.ts
+++ b/infrastructure/lib/observability-stack.ts
@@ -4,14 +4,22 @@
 
 import { Stack, StackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { Dashboard, TextWidget } from "aws-cdk-lib/aws-cloudwatch";
-import { IObservabilityContributor } from "./shared/common-observability";
+import { Dashboard, TextWidget, GraphWidget } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  IObservabilityContributor,
+  STANDARD_RESOLUTION,
+  SIZE_FULL_WIDTH,
+} from "./shared/common-observability";
+
+import * as apigateway from "aws-cdk-lib/aws-apigateway";
 
 /**
  * Configuration properties for the observability stack.
  */
 interface ObservabilityStackProps extends StackProps {
   readonly stage: string;
+
+  readonly restApi: apigateway.RestApi;
 }
 
 /**
@@ -29,24 +37,61 @@ export class ObservabilityStack extends Stack {
 
     this.dashboard.addWidgets(
       new TextWidget({
-        markdown: `# Zoorl - Function Metrics 
-Here you can see all the metrics for the *Zoorl* stack. These includes
-
-## Available metrics
+        markdown: `
+# Zoorl 
+Here you can see all the metrics for the *Zoorl* stack. These includes@
+* API Gateway (global)
 * Lambda functions
-
-## TODO metrics
-* API Gateway
 * DynamoDB tables
-                `,
+`,
         width: 24,
-        height: 6,
+        height: 3,
       })
     );
 
     // Note: sections are contributed by microservices implementing IObservabilityContributor
+
+    // API Gateway (REST API) is shared resource across different microservices
+    // TODO In future we may want to add "resource" dimensions so that we can track errors for
+    // specific microservices.
+    this.dashboard.addWidgets(
+      new TextWidget({
+        markdown: `
+# REST API metrics 
+Peformance metrics for the API Gateway supporting the REST API.
+
+## Metadata
+* name: ${props.restApi.restApiName}
+* Domain name: ${props.restApi.domainName?.domainName}
+`,
+        width: SIZE_FULL_WIDTH,
+        height: 4, // Increase this if you want to avoid vscrolls for long text
+      })
+    );
+
+    this.dashboard.addWidgets(
+      new GraphWidget({
+        title: "APIGateway requests, client errors, and server errors",
+        width: SIZE_FULL_WIDTH,
+        left: [props.restApi.metricCount({ period: STANDARD_RESOLUTION })],
+        right: [
+          props.restApi.metricClientError({ period: STANDARD_RESOLUTION }),
+          props.restApi.metricServerError({ period: STANDARD_RESOLUTION }),
+        ],
+      }),
+      new GraphWidget({
+        title: "APIGateway latency",
+        width: SIZE_FULL_WIDTH,
+        left: [props.restApi.metricLatency({ period: STANDARD_RESOLUTION, statistic: "p99", label: "p99 latency" })],
+      })
+    );
   }
 
+  /**
+   * Process the specified list of widgets contributors, allowing them to append widgets to the dahboard.
+   *
+   * @param contributors widgets contributors for the Cloudwatch dashboard.
+   */
   hookDashboardContributions(contributors: IObservabilityContributor[]): void {
     if (!contributors) return;
 

--- a/infrastructure/lib/zoorl-infrastructure-stack.ts
+++ b/infrastructure/lib/zoorl-infrastructure-stack.ts
@@ -50,6 +50,7 @@ export class ZoorlInfrastructureStack extends cdk.Stack {
 
     const observabilityStack = new ObservabilityStack(this, "observability", {
       stage: props.stage,
+      restApi: restApi
     });
     observabilityStack.hookDashboardContributions(observableStacks);
   }


### PR DESCRIPTION
This PR adds the metrics (with related helper methods) for DynamoDB and API Gateway.

API Gateway is considered to be a global resource, not a microservice-specific one. This may change in the future but we have at least a starting point for monitoring the system.