### PR TITLE
Separate Get URL Hash and Perform Redirect lambda functions

### DIFF
--- a/src/zoorl/zoorl/adapters/create_url_hash_handler.py
+++ b/src/zoorl/zoorl/adapters/create_url_hash_handler.py
@@ -1,33 +1,19 @@
 """AWS Lambda adapter for executing the use case for creating a new URL hash."""
 
 from typing import Any
-import boto3  
-import os
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
 
-from zoorl.adapters.dynamodb_model import DynamoDBUrlHashRepository
+from zoorl.adapters.lambda_support import app, tracer, logger, url_hash_repository
 
 from zoorl.core.usecases.create_url_hash import (
     CreateUrlHashUseCaseRequest,
     CreateUrlHashUseCase
 )
 
-tracer = Tracer()
-logger = Logger()
-app = APIGatewayRestResolver()
-
-dynamodb = boto3.resource("dynamodb")
-
 usecase = CreateUrlHashUseCase(
-    url_hash_repository=DynamoDBUrlHashRepository(
-        dynamodb.Table(
-            os.getenv("URL_HASHES_TABLE")
-        )
-    )
+    url_hash_repository=url_hash_repository
 )
 
 @app.post("/u")

--- a/src/zoorl/zoorl/adapters/lambda_support.py
+++ b/src/zoorl/zoorl/adapters/lambda_support.py
@@ -1,0 +1,94 @@
+"""AWS Lambda adapter for implementing the redirection use case.
+
+This adapter will invoke the use case for reading the hash and 
+provide two different behaviors:
+  1. /u/{url_hash} - will return the JSON object associated to the 
+    URL hash or HTTP 404 if not found  
+  2. /r/{url_hash} - will perform HTTP 301 redirect by setting the 
+    location header in the repose
+
+Case 1 if for clients while case 2 actually performs the desired
+redirect behavior of inducing the client web browser to perform 
+redirection to the mapped site.
+"""
+
+import boto3  
+import json
+import os
+
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import APIGatewayAuthorizerRequestEvent
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+    Response, 
+    content_types
+)
+from aws_lambda_powertools.logging import correlation_paths
+
+from zoorl.adapters.dynamodb_model import DynamoDBUrlHashRepository
+from zoorl.core.usecases.read_url_hash import UrlHashNotFoundError
+from zoorl.adapters import http_response_codes
+
+tracer = Tracer()
+logger = Logger()
+app = APIGatewayRestResolver()
+
+dynamodb = boto3.resource("dynamodb")
+
+url_hash_repository = DynamoDBUrlHashRepository(
+    dynamodb.Table(
+        os.getenv("URL_HASHES_TABLE")
+    )
+)
+
+@app.exception_handler(UrlHashNotFoundError)
+def handle_invalid_limit_qs(ex: UrlHashNotFoundError) -> Response:
+    """Returns a HTTP 404 response is the the requested URL hash is not found. 
+     
+    The use case will throw this exception if not such URL hash is found,
+    so we are only intercepting that exception and acting accordingly.
+    
+    Arguments:
+        ex: the exception
+
+    Returns:
+        The configured HTTP 404 'Response' object    
+    """
+
+    metadata = {"path": app.current_event.path, "query_strings": app.current_event.query_string_parameters}
+    logger.error(f"Malformed request: {ex}", extra=metadata)
+
+    return Response(
+        status_code = http_response_codes.NOT_FOUND,
+        content_type = content_types.APPLICATION_JSON,
+        body = json.dumps({
+            "message": str(ex)
+        })
+    )
+
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
+@tracer.capture_lambda_handler
+def handle(event: APIGatewayAuthorizerRequestEvent, context: LambdaContext) -> dict:
+    """AWS Lambda entry point function.
+
+    Note that we relay on AWS Lambda Powertools for Python to process our 
+    response and set fields when needed.
+
+    Arguments:
+        event: the APIGateway event payload 
+        context: Lambda context (e.g., environment variables)
+
+    Returns:
+        Response suitable for being processed by API Gateway.
+    """
+
+    logger.info(f"Context \"{context}\" .")
+
+    logger.debug(f"Correlation ID => {logger.get_correlation_id()}")
+    
+    response = app.resolve(event, context)
+
+    logger.info(f"Response \"{response}\" .")
+
+    return response

--- a/src/zoorl/zoorl/adapters/read_url_hash_handler.py
+++ b/src/zoorl/zoorl/adapters/read_url_hash_handler.py
@@ -3,55 +3,31 @@
 This adapter will invoke the use case, and format the HTTP response to instruct
 the client web browser to perform redirection to the mapped site.
 """
-import boto3  
-import json
-import os
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import APIGatewayAuthorizerRequestEvent
-from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.event_handler import (
-    APIGatewayRestResolver,
-    Response, 
-    content_types
-)
 from aws_lambda_powertools.logging import correlation_paths
 
-from zoorl.adapters.dynamodb_model import DynamoDBUrlHashRepository
 from zoorl.core.usecases.read_url_hash import (
     ReadUrlHashUseCase,
-    ReadUrlHashUseCaseRequest,
-    UrlHashNotFoundError
+    ReadUrlHashUseCaseRequest
 )
-from zoorl.adapters import http_response_codes
-
-tracer = Tracer()
-logger = Logger()
-app = APIGatewayRestResolver()
-
-dynamodb = boto3.resource("dynamodb")
+from zoorl.adapters.lambda_support import app, tracer, logger, url_hash_repository
 
 usecase = ReadUrlHashUseCase(
-    url_hash_repository=DynamoDBUrlHashRepository(
-        dynamodb.Table(
-            os.getenv("URL_HASHES_TABLE")
-        )
-    )
+    url_hash_repository=url_hash_repository
 )
 
 @app.get("/u/<url_hash>")
 @tracer.capture_method
-def handle(url_hash: str) -> Response:
-    """Returns the HTTP 301 response that will trigger redirection.
-    
-    On receiving an HTTP 301 response and 'Location' header, we trigger the 
-    client web browser to perform redirection to the specified page.
+def handle(url_hash: str) -> dict:
+    """Returns the URL Hash data for the specified resource.
     
     Arguments:
         url_hash: the desired URL hash
 
     Returns:
-        The configured HTTP 301 Permanently Moved 'Response' object object    
+        the URL hash information.   
     
     Raises:
         UrlHashNotFoundError: if the hash was not found
@@ -63,37 +39,12 @@ def handle(url_hash: str) -> Response:
 
     logger.info(f"Got response for hash \"{url_hash}\": {response.url} .")
 
-    return Response(
-        status_code = http_response_codes.MOVED_PERMANENTLY,
-        headers = {
-            "Location": response.url
-        },
-        content_type = content_types.TEXT_HTML, # We always redirect to another HTML page
-        body = None # there is no body, but the argument is mandatory
-    )
+    return {
+        "url_hash": response.url_hash,
+        "url": response.url,
+        "ttl": response.ttl
+    }
 
-
-@app.exception_handler(UrlHashNotFoundError)
-def handle_invalid_limit_qs(ex: UrlHashNotFoundError) -> Response:
-    """Returns a HTTP 404 is the the requested URL hash is not found.
-    
-    Arguments:
-        ex: the exception
-
-    Returns:
-        The configured HTTP 404 'Response' object    
-    """
-
-    metadata = {"path": app.current_event.path, "query_strings": app.current_event.query_string_parameters}
-    logger.error(f"Malformed request: {ex}", extra=metadata)
-
-    return Response(
-        status_code = http_response_codes.NOT_FOUND,
-        content_type = content_types.APPLICATION_JSON,
-        body = json.dumps({
-            "message": str(ex)
-        })
-    )
 
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
 @tracer.capture_lambda_handler

--- a/src/zoorl/zoorl/adapters/redirect_handler.py
+++ b/src/zoorl/zoorl/adapters/redirect_handler.py
@@ -1,0 +1,87 @@
+"""AWS Lambda adapter for implementing the redirection use case.
+
+This adapter will invoke the use case for reading the URL hash 
+and will perform HTTP 301 redirect by setting the  location header
+in the reponse.
+
+This will trigger the client web browser to perform redirection 
+to the mapped site.
+"""
+
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import APIGatewayAuthorizerRequestEvent
+from aws_lambda_powertools.event_handler import (
+    Response, 
+    content_types
+)
+from aws_lambda_powertools.logging import correlation_paths
+
+from zoorl.core.usecases.read_url_hash import (
+    ReadUrlHashUseCase,
+    ReadUrlHashUseCaseRequest
+)
+from zoorl.adapters import http_response_codes
+from zoorl.adapters.lambda_support import app, tracer, logger, url_hash_repository
+
+usecase = ReadUrlHashUseCase(
+    url_hash_repository=url_hash_repository
+)
+
+@app.get("/r/<url_hash>")
+@tracer.capture_method
+def handle_redirect(url_hash: str) -> Response:
+    """Returns the HTTP 301 response that will trigger redirection.
+    
+    On receiving an HTTP 301 response and 'Location' header, we trigger the 
+    client web browser to perform redirection to the specified page.
+    
+    Arguments:
+        url_hash: the desired URL hash
+
+    Returns:
+        The configured HTTP 301 Permanently Moved 'Response' object object    
+    
+    Raises:
+        UrlHashNotFoundError: if the hash was not found
+    """
+    
+    logger.info(f"Returning URL for hash \"{url_hash}\" .")
+
+    response = usecase.read_url(ReadUrlHashUseCaseRequest(hash = url_hash))
+
+    logger.info(f"Got response for hash \"{url_hash}\": {response.url} .")
+
+    return Response(
+        status_code = http_response_codes.MOVED_PERMANENTLY,
+        headers = {
+            "Location": response.url
+        },
+        content_type = content_types.TEXT_HTML, # We always redirect to another HTML page
+        body = None # there is no body, but the argument is mandatory
+    )
+
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
+@tracer.capture_lambda_handler
+def handle(event: APIGatewayAuthorizerRequestEvent, context: LambdaContext) -> dict:
+    """AWS Lambda entry point function.
+
+    Note that we relay on AWS Lambda Powertools for Python to process our 
+    response and set fields when needed.
+
+    Arguments:
+        event: the APIGateway event payload 
+        context: Lambda context (e.g., environment variables)
+
+    Returns:
+        Response suitable for being processed by API Gateway.
+    """
+
+    logger.info(f"Context \"{context}\" .")
+
+    logger.debug(f"Correlation ID => {logger.get_correlation_id()}")
+    
+    response = app.resolve(event, context)
+
+    logger.info(f"Response \"{response}\" .")
+
+    return response


### PR DESCRIPTION
This PR separates the two mentioned functions - a shared_lambda.py module was created to share code between the different python functions.

The CDK App has been updated to map the functions correctly:
* POST /u - creates the URL hash
* GET /u/{url_hash} - returns the URL hash (as JSON)
* GET /r/{url_hash}  - returns the HTTP 301 answer for redirect

Functions have been tested manually and they seem to be working correctly